### PR TITLE
FEAT(news): add GET /sources endpoint for fetching news sources

### DIFF
--- a/src/modules/News/controller.ts
+++ b/src/modules/News/controller.ts
@@ -13,4 +13,21 @@ const getLatestNews = async (req: Request, res: Response) => {
   }
 };
 
-export default { getLatestNews };
+const getSources = async (req: Request, res: Response) => {
+  const { language, country, category } = req.query;
+  
+    try {
+     const sources = await fetchFromNewsAPI('/sources', {
+      language, 
+      country,  
+      category, 
+    });
+    res.status(200).send(sources.sources);
+  } catch (error) {
+    res
+      .status(500)
+      .send({ message: 'Error in fetching News Sources', error });
+  }
+};
+
+export default { getLatestNews, getSources };


### PR DESCRIPTION
- Implement `getSources` controller function to handle GET /sources requests.
- Integrated query parameters (`language`, `country`, `category`) for filtering of news sources.
- Used `fetchFromNewsAPI` utility to interact with the News API's /sources endpoint.
- Added error handling with a try-catch block
