### PR TITLE
Add utility function and types for fetching single article

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -15,3 +15,10 @@ export interface IArticles {
   publishedAt: string;
   content: string;
 }
+
+export interface FetchArticleParams {
+  title: string;
+  description?: string;
+  source?: string;
+  publishedAt?: string;
+}


### PR DESCRIPTION
Relates to #19

This PR introduces a utility function to fetch a single article from the NewsAPI using dynamic parameters such as title, description, and published date. Includes type definitions for better maintainability and consistency.

Files changed:
 - src/utils.ts
 - src/types/types.ts
 
 Adding as a draft while creating a new endpoint to test if the function is working. Not ready for review.