### PR TITLE
feat: Add GET endpoints for sources and search 

### DIFF
--- a/src/modules/News/controller.ts
+++ b/src/modules/News/controller.ts
@@ -87,10 +87,11 @@ const getSources = async (req: Request, res: Response) => {
       country,
       category,
     });
+    res.status(200).send(sources.sources);
   } catch (error) {
     res
-    .status(500)
-    .send({ message: 'Error in fetching source results', error,});
+      .status(500)
+      .send({ message: 'Error in fetching source results', error });
   }
 };
 
@@ -108,8 +109,8 @@ const getSearchResults = async (req: Request, res: Response) => {
     res.status(200).send(articles.articles);
   } catch (error) {
     res
-    .status(500)
-    .send({ message: 'Error in fetching search results', error,});
+      .status(500)
+      .send({ message: 'Error in fetching search results', error });
   }
 };
 

--- a/src/modules/News/controller.ts
+++ b/src/modules/News/controller.ts
@@ -87,9 +87,10 @@ const getSources = async (req: Request, res: Response) => {
       country,
       category,
     });
-    res.status(200).send(sources.sources);
   } catch (error) {
-    res.status(500).send({ message: 'Error in getting News Sources', error });
+    res
+    .status(500)
+    .send({ message: 'Error in fetching source results', error,});
   }
 };
 
@@ -106,10 +107,9 @@ const getSearchResults = async (req: Request, res: Response) => {
 
     res.status(200).send(articles.articles);
   } catch (error) {
-    res.status(500).send({
-      message: 'Error in fetching search results',
-      error,
-    });
+    res
+    .status(500)
+    .send({ message: 'Error in fetching search results', error,});
   }
 };
 

--- a/src/modules/News/controller.ts
+++ b/src/modules/News/controller.ts
@@ -78,4 +78,45 @@ const getTopHeadlines = async (req: Request, res: Response) => {
   }
 };
 
-export default { getLatestNews, getTopHeadlines, getPersonalizedNews };
+const getSources = async (req: Request, res: Response) => {
+  const { language, country, category } = req.query;
+
+  try {
+    const sources = await fetchFromNewsAPI('/sources', {
+      language,
+      country,
+      category,
+    });
+    res.status(200).send(sources.sources);
+  } catch (error) {
+    res.status(500).send({ message: 'Error in getting News Sources', error });
+  }
+};
+
+const getSearchResults = async (req: Request, res: Response) => {
+  const { q, from, to, sortBy } = req.query;
+
+  try {
+    const articles = await fetchFromNewsAPI('/everything', {
+      q,
+      from,
+      to,
+      sortBy,
+    });
+
+    res.status(200).send(articles.articles);
+  } catch (error) {
+    res.status(500).send({
+      message: 'Error in fetching search results',
+      error,
+    });
+  }
+};
+
+export default {
+  getLatestNews,
+  getTopHeadlines,
+  getPersonalizedNews,
+  getSources,
+  getSearchResults,
+};

--- a/src/modules/News/routes.ts
+++ b/src/modules/News/routes.ts
@@ -32,6 +32,7 @@ router.get(
 
 router.get(
   '/search',
+  authMiddleWare,
   validateRequest(newsValidationSchemas.searchResults),
   newsController.getSearchResults,
 );

--- a/src/modules/News/routes.ts
+++ b/src/modules/News/routes.ts
@@ -24,4 +24,16 @@ router.get(
   newsController.getTopHeadlines,
 );
 
+router.get(
+  '/sources',
+  validateRequest(newsValidationSchemas.sources),
+  newsController.getSources,
+);
+
+router.get(
+  '/search',
+  validateRequest(newsValidationSchemas.searchResults),
+  newsController.getSearchResults,
+);
+
 export default router;

--- a/src/modules/News/validation.ts
+++ b/src/modules/News/validation.ts
@@ -45,15 +45,7 @@ const sources = {
     language: Joi.string().length(2).optional(),
     country: Joi.string().length(2).optional(),
     category: Joi.string()
-      .valid(
-        'business',
-        'entertainment',
-        'general',
-        'health',
-        'science',
-        'sports',
-        'technology',
-      )
+      .valid(...categories)
       .optional(),
   }),
 };

--- a/src/modules/News/validation.ts
+++ b/src/modules/News/validation.ts
@@ -40,4 +40,41 @@ const headlines = {
   }),
 };
 
-export default { latestNews, headlines, personalizedNews };
+const sources = {
+  query: Joi.object({
+    language: Joi.string().length(2).optional(),
+    country: Joi.string().length(2).optional(),
+    category: Joi.string()
+      .valid(
+        'business',
+        'entertainment',
+        'general',
+        'health',
+        'science',
+        'sports',
+        'technology',
+      )
+      .optional(),
+  }),
+};
+
+const searchResults = {
+  query: Joi.object({
+    q: Joi.string().required(),
+    from: Joi.date().optional().iso(),
+    to: Joi.date().optional().iso(),
+    sortBy: Joi.string()
+      .optional()
+      .valid('relevancy', 'popularity', 'publishedAt')
+      .default('publishedAt'),
+    limit: Joi.number().integer().min(1).max(100).default(5),
+  }),
+};
+
+export default {
+  latestNews,
+  headlines,
+  personalizedNews,
+  searchResults,
+  sources,
+};


### PR DESCRIPTION
- Implemented /sources and /search GET endpoints in the routes.
- Created validation schemas for sources and searches using Joi.
- Added controllers to fetch news sources and search results from the News API.
- Connected routes to their respective controller functions for processing requests.

This Branch is a followup on this closed PR  https://github.com/StartSteps-Digital-Education-GmbH/News-App/pull/15