### PR TITLE
Add networks and healthcheck to docker to communicate with the frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - .env.prod
     volumes:
       - ./init-database.sh:/docker-entrypoint-initdb.d/init-database.sh
+    networks:
+      - backend-db-network 
   
   news_app:
     build:
@@ -23,5 +25,21 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+        restart: true
     env_file:
       - .env.prod
+    networks:
+      - backend-db-network 
+      - backend-frontend-network
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:5000/api/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+networks:
+  backend-db-network:
+    driver: bridge
+  backend-frontend-network:
+    driver: bridge
+    external: true

--- a/src/healthController.ts
+++ b/src/healthController.ts
@@ -1,0 +1,24 @@
+import type { Request, Response } from 'express';
+import { AppDataSource } from './config/database.js';
+
+const health = async (req: Request, res: Response) => {
+  try {
+    if (AppDataSource.isInitialized) {
+      res.status(200).send({ status: 'UP', message: 'Service is healthy' });
+      return;
+    } else {
+      res
+        .status(500)
+        .send({ status: 'DOWN', message: 'Database connection lost' });
+      return;
+    }
+  } catch (error: any) {
+    res.status(500).send({
+      status: 'DOWN',
+      message: 'Healthy check failed',
+      error: error.message,
+    });
+  }
+};
+
+export default { health };

--- a/src/healthRoute.ts
+++ b/src/healthRoute.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import healthController from './healthController.js'
+import healthController from './healthController.js';
 
 const router = Router();
 

--- a/src/healthRoute.ts
+++ b/src/healthRoute.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import healthController from './healthController.js'
+
+const router = Router();
+
+router.get('/health', healthController.health);
+
+export default router;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -4,7 +4,7 @@ import userRoutes from './modules/User/routes.js';
 import newsRoutes from './modules/News/routes.js';
 import bookmarkRouter from './modules/Bookmark/routes.js';
 import commentsRoutes from './modules/Comment/routes.js';
-import healthRouter from './healthController.js'
+import healthRouter from './healthController.js';
 
 const router = Router();
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -4,9 +4,11 @@ import userRoutes from './modules/User/routes.js';
 import newsRoutes from './modules/News/routes.js';
 import bookmarkRouter from './modules/Bookmark/routes.js';
 import commentsRoutes from './modules/Comment/routes.js';
+import healthRouter from './healthController.js'
 
 const router = Router();
 
+router.use('/health', healthRouter.health);
 router.use('/users', userRoutes);
 router.use('/news', newsRoutes);
 router.use('/bookmarks', bookmarkRouter);


### PR DESCRIPTION
This PR adds networks to the docker to open communication with the frontend container (backend-frontend-network) and sets the network for the backend and database (backend-db-network).

I also added the /health endpoint so the front end can check if the back end is running. This endpoint can be used when building the front-end container and when the front end needs to contact the APIs, for example, to check the connection.

![image](https://github.com/user-attachments/assets/bd9de406-468c-4713-a7fb-1e4e15cb5884)